### PR TITLE
Write uploaded ZIP in chunks

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,9 +32,13 @@ async def process_zip(
 
     should_cleanup = True
     try:
-        # 1. Guardar .zip subido
+        # 1. Guardar .zip subido sin cargar todo en memoria
         with open(zip_in, "wb") as f:
-            f.write(await file.read())
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                f.write(chunk)
         # 2. Descomprimir
         os.makedirs(in_dir, exist_ok=True)
         with zipfile.ZipFile(zip_in, 'r') as zf:


### PR DESCRIPTION
## Summary
- avoid loading the entire uploaded file into memory by writing chunks to disk

## Testing
- `python -m py_compile main.py handler.py`


------
https://chatgpt.com/codex/tasks/task_e_6851fa4f74048333b9861b00090137a6